### PR TITLE
fix: Replace NetcodePatcher action with MSBuild

### DIFF
--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -18,15 +18,9 @@ runs:
       shell: bash
       run: dotnet restore
 
-    - name: Setup Netcode Patcher
-      id: setup-netcode-patcher
-      uses: Lordfirespeed/setup-netcode-patcher@v0
-      with:
-        netcode-patcher-version: 2.4.0
-        # https://www.nuget.org/packages/LethalCompany.GameLibs.Steam
-        # Must be the same version as the one used in the project
-        deps-packages: '[{"id": "UnityEngine.Modules", "version": "2022.3.9"}, {"id": "LethalCompany.GameLibs.Steam", "version": "49.0.0-alpha.1"}]'
-        target-framework: "netstandard2.1"
+    - name: Install NetcodePatcher
+      shell: bash
+      run: dotnet tool install -g evaisa.netcodepatcher.cli
 
     - name: Install Thunderstore client
       if: ${{ inputs.thunderstore-client == 'true' }}

--- a/Template/Template.csproj
+++ b/Template/Template.csproj
@@ -35,7 +35,6 @@
     <!-- https://github.com/EvaisaDev/UnityNetcodePatcher#usage-as-a-post-build-event -->
     <!-- Syntax to use the tool installed globally -->
     <!-- Allows to patch elements like networked behaviours, RPCs, etc. -->
-    <!-- Also, without that, the CI/CD will fail because the game's assemblies are not findable -->
     <Target Name="NetcodePatch" AfterTargets="PostBuildEvent">
         <Exec Command="netcode-patch &quot;$(TargetPath)&quot; @(ReferencePathWithRefAssemblies->'&quot;%(Identity)&quot;', ' ')"/>
     </Target>

--- a/Template/Template.csproj
+++ b/Template/Template.csproj
@@ -32,16 +32,10 @@
         <PackageReference Include="UnityEngine.Modules" Version="2022.3.9" IncludeAssets="compile"/>
     </ItemGroup>
 
-    <ItemGroup>
-        <!-- https://github.com/EvaisaDev/UnityNetcodePatcher -->
-        <!-- Allows to patch elements like networked behaviours, RPCs, etc. -->
-        <!-- Also, without that, the CI/CD will fail because the game's assemblies are not findable -->
-        <PackageReference Include="Evaisa.NetcodePatcher.MSBuild" Version="3.*" PrivateAssets="all"/>
-        <NetcodePatch Include="$(TargetPath)"/>
-    </ItemGroup>
-
     <!-- https://github.com/EvaisaDev/UnityNetcodePatcher#usage-as-a-post-build-event -->
     <!-- Syntax to use the tool installed globally -->
+    <!-- Allows to patch elements like networked behaviours, RPCs, etc. -->
+    <!-- Also, without that, the CI/CD will fail because the game's assemblies are not findable -->
     <Target Name="NetcodePatch" AfterTargets="PostBuildEvent">
         <Exec Command="netcode-patch &quot;$(TargetPath)&quot; @(ReferencePathWithRefAssemblies->'&quot;%(Identity)&quot;', ' ')"/>
     </Target>

--- a/Template/Template.csproj
+++ b/Template/Template.csproj
@@ -32,6 +32,20 @@
         <PackageReference Include="UnityEngine.Modules" Version="2022.3.9" IncludeAssets="compile"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <!-- https://github.com/EvaisaDev/UnityNetcodePatcher -->
+        <!-- Allows to patch elements like networked behaviours, RPCs, etc. -->
+        <!-- Also, without that, the CI/CD will fail because the game's assemblies are not findable -->
+        <PackageReference Include="Evaisa.NetcodePatcher.MSBuild" Version="3.*" PrivateAssets="all"/>
+        <NetcodePatch Include="$(TargetPath)"/>
+    </ItemGroup>
+
+    <!-- https://github.com/EvaisaDev/UnityNetcodePatcher#usage-as-a-post-build-event -->
+    <!-- Syntax to use the tool installed globally -->
+    <Target Name="NetcodePatch" AfterTargets="PostBuildEvent">
+        <Exec Command="netcode-patch &quot;$(TargetPath)&quot; @(ReferencePathWithRefAssemblies->'&quot;%(Identity)&quot;', ' ')"/>
+    </Target>
+
     <!-- Avoid that the game's assemblies are copied to the plugin's target directory -->
     <Target Name="ClearReferenceCopyLocalPaths" AfterTargets="ResolveAssemblyReferences">
         <ItemGroup>
@@ -58,11 +72,11 @@
 
     <!-- Build the plugin for Thunderstore publication -->
     <!-- The command will create a zip file in the target directory using the thunderstore.toml file -->
-    <Target Condition="'$(BuildThunderstorePackage)' == 'true'" Name="ThunderstoreBuild" AfterTargets="PostBuildEvent" DependsOnTargets="MinVer">
+    <Target Condition="'$(BuildThunderstorePackage)' == 'true'" Name="ThunderstoreBuild" AfterTargets="PostBuildEvent" DependsOnTargets="MinVer;NetcodePatch">
         <PropertyGroup>
             <PluginVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)</PluginVersion>
         </PropertyGroup>
         <!-- https://github.com/thunderstore-io/thunderstore-cli/wiki -->
-        <Exec Command="tcli build --config-path $(SolutionDir)thunderstore.toml --package-version $(PluginVersion)" />
+        <Exec Command="tcli build --config-path $(SolutionDir)thunderstore.toml --package-version $(PluginVersion)"/>
     </Target>
 </Project>


### PR DESCRIPTION
## Checklist

<!--
Before submitting PR to Code Owners, please check if your PR fulfills the following requirements:

Please check the one that applies to this PR using "x"
-->

- [x] The code is tested (if applicable)
- [x] The plugin works as expected in the game
- [x] The documentation is up to date (if needed)

## Description

According to the advice of [Lordfirespeed](https://github.com/Lordfirespeed) (the owner of the action used to patch the project), we need to use the library https://github.com/EvaisaDev/UnityNetcodePatcher. This library is maintained and allows us to patch locally the project.

❤️ Thank you!
